### PR TITLE
Fix default conversion logic

### DIFF
--- a/sqlavro/column.go
+++ b/sqlavro/column.go
@@ -106,7 +106,7 @@ func sqlDefault2AVRODefault(dataType SQLType, sqlDefaultValue []byte) (avroDefau
 		Text, TinyText, MediumText, LongText,
 		Enum, Set:
 		return []byte(fmt.Sprintf(`"%s"`, string(sqlDefaultValue)))
-	case Date, Time, DateTime:
+	case Date, Time, DateTime, Timestamp:
 		var format string
 		switch dataType {
 		case Date:


### PR DESCRIPTION
In the case of a Timestamp with a default of CURRENT_TIMESTAMP this default conversion was failing because the enclosing switch wasn't capturing Timestamp at all